### PR TITLE
Removed Hard-Coded Username

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -70,13 +70,13 @@ class UserPublicRepls extends replapi.CustomDataQuery {
 	}
 }
 
-const myUser = new UserPublicRepls('RayhanADev');
 
 /**
  * Fetchs all of a user's Repls
  * @param username <String> - a username
  */
 async function fetchRepls(username) {
+	const myUser = new UserPublicRepls(username);
 	const info = await myUser.getData();
 	return info.userByUsername.publicRepls.items.map((repl) => {
 		if (repl.slug !== process.env.REPL_SLUG)


### PR DESCRIPTION
**Problem:** When I ran the script it backed up your REPLs, instead of mine. Even though I was correctly passing my username as a command line argument.

**Solution:** Your username was hard-coded in the line creating the REPLapi Custom Data Query:

```javascript
const myUser = new UserPublicRepls('RayhanADev');
```

I moved this line into the `fetchRepls` function and replaced the hard-coded username with the `username` function parameter. 

The script now works as expected. 

**Note:** Your username is still hard-coded on line 8 as the API user:

```javascript
const replapi = ReplAPI({
	username: 'RayhanADev',
});
```